### PR TITLE
Disable Ingress Routing to Service

### DIFF
--- a/.github/workflows/cicd-dev.yaml
+++ b/.github/workflows/cicd-dev.yaml
@@ -129,8 +129,7 @@ jobs:
           --namespace $K8S_NAMESPACE \
           --values ./helm/values.yaml \
           --values "$VALUES_FILE" \
-          --set image="${{ needs.build-and-push.outputs.image_tag }}" \
-          --set ingress.defaultHost="$INGRESS_IP.nip.io"
+          --set image="${{ needs.build-and-push.outputs.image_tag }}"
 
 
   # TODO: Smoke tests on dev deployment

--- a/.github/workflows/cicd-dev.yaml
+++ b/.github/workflows/cicd-dev.yaml
@@ -110,6 +110,7 @@ jobs:
 
         echo "RESOURCE_GROUP_NAME=$(fetch_secret rg-name)" >> $GITHUB_ENV
         echo "AKS_CLUSTER_NAME=$(fetch_secret aks-name)" >> $GITHUB_ENV
+        echo "INGRESS_IP=$(fetch_secret ingress-ip)" >> $GITHUB_ENV
 
     - name: Update Chart appVersion
       run: |
@@ -128,7 +129,8 @@ jobs:
           --namespace $K8S_NAMESPACE \
           --values ./helm/values.yaml \
           --values "$VALUES_FILE" \
-          --set image="${{ needs.build-and-push.outputs.image_tag }}"
+          --set image="${{ needs.build-and-push.outputs.image_tag }}" \
+          --set ingress.defaultHost="$INGRESS_IP.nip.io"
 
 
   # TODO: Smoke tests on dev deployment

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -7,13 +7,25 @@ metadata:
     {{- include "helm.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+    {{- if .Values.ingress.tls.enabled }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
+    {{- end }}
 
 spec:
   ingressClassName: {{ .Values.ingress.className }}
-  # TODO: Add TLS configuration
+  
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        {{- range .Values.ingress.hosts }}
+        - {{ .host | default $.Values.ingress.defaultHost }}
+        {{- end }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | default "" }}
+    - host: {{ .host | default $.Values.ingress.defaultHost }}
       http:
         paths:
           {{- range .paths }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "helm.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
-    {{- if .Values.ingress.tls.enabled }}
+    {{- if .Values.ingress.tls.enabled && .Values.ingress.tls.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- end }}
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,7 +38,11 @@ ingress:
   className: nginx
   hosts:
     - paths:
+        # API endpoints
         - path: /api/courses/
+          pathType: Prefix
+        # Documentation endpoint
+        - path: /docs/courses/
           pathType: Prefix
 
 # Health check probes configuration

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -34,6 +34,7 @@ service:
 
 # Ingress configuration for external access
 ingress:
+  defaultHost: ""  # should be set via --set during helm install/upgrade
   enabled: true
   className: nginx
   hosts:
@@ -44,6 +45,10 @@ ingress:
         # Documentation endpoint
         - path: /docs/courses/
           pathType: Prefix
+  tls:
+    enabled: true
+    secretName: courses-tls
+    clusterIssuer: letsencrypt
 
 # Health check probes configuration
 probes:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -47,8 +47,7 @@ ingress:
           pathType: Prefix
   tls:
     enabled: true
-    secretName: courses-tls
-    clusterIssuer: letsencrypt
+    secretName: nip-tls
 
 # Health check probes configuration
 probes:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -32,22 +32,8 @@ service:
   type: ClusterIP
   port: 80
 
-# Ingress configuration for external access
 ingress:
-  defaultHost: ""  # should be set via --set during helm install/upgrade
-  enabled: true
-  className: nginx
-  hosts:
-    - paths:
-        # API endpoints
-        - path: /api/courses/
-          pathType: Prefix
-        # Documentation endpoint
-        - path: /docs/courses/
-          pathType: Prefix
-  tls:
-    enabled: true
-    secretName: nip-tls
+  enabled: false
 
 # Health check probes configuration
 probes:

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -22,6 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../utils/config.sh"
 RG_NAME=$(get_secret "rg-name")
 AKS_NAME=$(get_secret "aks-name")
+INGRESS_IP=$(get_secret "ingress-ip")
 
 # Authenticate to the AKS cluster
 source "$SCRIPT_DIR/../utils/authenticate.sh"
@@ -33,4 +34,5 @@ helm upgrade --install "$RELEASE_NAME" ./helm \
   --values ./helm/values.yaml \
   --values "$VALUES_FILE" \
   --set image="$IMAGE" \
+  --set ingress.defaultHost="$INGRESS_IP.nip.io" \
   --wait --timeout 5m

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -34,5 +34,4 @@ helm upgrade --install "$RELEASE_NAME" ./helm \
   --values ./helm/values.yaml \
   --values "$VALUES_FILE" \
   --set image="$IMAGE" \
-  --set ingress.defaultHost="$INGRESS_IP.nip.io" \
   --wait --timeout 5m

--- a/src/app.js
+++ b/src/app.js
@@ -29,11 +29,11 @@ app.use(express.json());
 
 // Scalar API reference
 const openapi = YAML.load("./openapi.yaml");
-app.get("/openapi.json", (_req, res) => res.json(openapi));
+app.get("/docs/courses/openapi.json", (_req, res) => res.json(openapi));
 app.use(
-  "/docs",
+  "/docs/courses",
   apiReference({
-    spec: { url: "/openapi.json" },
+    url: "/docs/courses/openapi.json",
     theme: "default",
     darkMode: true,
   })

--- a/src/app.js
+++ b/src/app.js
@@ -29,11 +29,11 @@ app.use(express.json());
 
 // Scalar API reference
 const openapi = YAML.load("./openapi.yaml");
-app.get("/openapi.json", (_req, res) => res.json(openapi));
+app.get("/docs/courses/openapi.json", (_req, res) => res.json(openapi));
 app.use(
-  "/docs",
+  "/docs/courses",
   apiReference({
-    spec: { url: "/openapi.json" },
+    url: "openapi.json",
     theme: "default",
     darkMode: true,
   })


### PR DESCRIPTION
Removed ingress routing to the service, as it should not be exposed eternally directly, but rather through the API gateway (`svc-gateway`) service.